### PR TITLE
Debian 12.5 Support Confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,15 @@ distributions and versions here that I know have been tested with this method.
 On Ubuntu 22.04, Firefox will only work if you allow the script to remove the
 `snap` version and reinstall the browser with `apt`.
 
-| Distribution | Versions  | Browsers        |
-|    :-:       |    :-:    |       :-:       |
-| Ubuntu       | 20.04 LTS | Firefox, Chrome |
-|              | 22.04 LTS | Firefox, Chrome |
-| PopOS!       | 20.04 LTS | Firefox, Chrome |
-|              | 22.04 LTS | Firefox, Chrome |
-| Mint         | 21.2      | Firefox, Chrome |
-| Parrot OS    | 6.0.0-2   | Firefox, Brave  |
+| Distribution | Versions  | Browsers                  |
+|    :-:       |    :-:    |       :-:                 |
+| Debian       | 12.5      | Firefox ESR, Chrome, Edge |
+| Mint         | 21.2      | Firefox, Chrome           |
+| PopOS!       | 20.04 LTS | Firefox, Chrome           |
+|              | 22.04 LTS | Firefox, Chrome           |
+| Parrot OS    | 6.0.0-2   | Firefox, Brave            |
+| Ubuntu       | 20.04 LTS | Firefox, Chrome           |
+|              | 22.04 LTS | Firefox, Chrome           |
 
 **NOTE:** There are reports of this script working with other distributions and
 browsers. I have not personally tested these configurations.

--- a/cac_setup.sh
+++ b/cac_setup.sh
@@ -361,9 +361,9 @@ check_for_firefox ()
                 print_err "This version of Firefox was installed as a snap package with a launch script"
             else
                 # Run Firefox to ensure .mozilla directory has been created
-                echo -e "Running Firefox to generate profile directory..."
+                print_info "Running Firefox to generate profile directory..."
                 run_firefox
-                echo -e "\tDone."
+                print_info "Done."
             fi
         else
             print_info "Firefox not found."
@@ -432,7 +432,7 @@ import_certs ()
         done
     fi
 
-    echo "Done."
+    print_info "Done."
     echo
 } # import_certs
 


### PR DESCRIPTION
I tested and confirmed the script works with Debian 12.5. Below are screenshots verifying this.

Firefox ESR:

![Screenshot from 2024-04-18 17-13-22](https://github.com/jdjaxon/linux_cac/assets/16808380/3365a5de-2573-4717-9e86-311772a36126)

Chrome:

![Screenshot from 2024-04-18 17-14-57](https://github.com/jdjaxon/linux_cac/assets/16808380/3127a169-4c77-4288-860d-df7364839741)

Edge:

![Screenshot from 2024-04-18 17-17-24](https://github.com/jdjaxon/linux_cac/assets/16808380/905b0ae0-01b2-43d1-9a87-4d53316936fb)
