### PR TITLE
Add (semi)automated integration testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/

--- a/cac_setup.sh
+++ b/cac_setup.sh
@@ -18,7 +18,6 @@ main ()
 
     ORIG_HOME="$(getent passwd "$SUDO_USER" | cut -d: -f6)"
     CERT_EXTENSION="cer"
-    # PKCS_FILENAME="pkcs11.txt"
     DB_FILENAME="cert9.db"
     CERT_FILENAME="AllCerts"
     BUNDLE_FILENAME="AllCerts.zip"
@@ -67,7 +66,7 @@ main ()
     systemctl enable pcscd.socket
     print_info "Done"
 
-    # Handle snapped firefox
+    # Connect snapped Firefox to the pcscd socket
     if [ "$snap_ff" == true ]
     then
         print_info "Connecting snapped Firefox to the pcscd socket..."
@@ -76,20 +75,21 @@ main ()
             print_err "Failed to connect. Try upgrading with 'apt upgrade' and 'snap refresh' first."
             exit "$E_BROWSER"
         fi
+    fi
 
-        print_info "Registering the pkcs11 module..."
-        sudo -H -u "$SUDO_USER" modutil -dbdir "sql:$ff_profile_dir" \
-            -add "CAC Module" -libfile /usr/lib/x86_64-linux-gnu/opensc-pkcs11.so -force
+    # Register the PKCS11 module in every detected NSS database (Firefox + Chrome)
+    opensc_lib=$(find_opensc_pkcs11)
+    if [ -z "$opensc_lib" ]
+    then
+        print_err "Could not locate opensc-pkcs11.so; skipping PKCS11 module registration."
     else
-        print_info "Registering CAC module with PKSC11..."
-        sudo -H -u "$SUDO_USER" pkcs11-register --skip-firefox=off
-        print_info "Done"
-
-        # NOTE: Keeping this temporarily to test `pkcs11-register`.
-        # if ! grep -Pzo 'library=/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so\nname=CAC Module\n' "$db_root/$PKCS_FILENAME" >/dev/null
-        # then
-        #     printf "library=/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so\nname=CAC Module\n" >> "$db_root/$PKCS_FILENAME"
-        # fi
+        for db in "${databases[@]}"
+        do
+            if [ -n "$db" ]
+            then
+                register_pkcs11_module "$(dirname "$db")" "$opensc_lib"
+            fi
+        done
     fi
 
 
@@ -266,6 +266,31 @@ import_certs ()
     print_info "Done."
     echo
 } # import_certs
+
+
+# Locate opensc-pkcs11.so on the system
+find_opensc_pkcs11 ()
+{
+    local lib_path
+    lib_path=$(dpkg -L opensc 2>/dev/null | grep 'opensc-pkcs11\.so$' | head -1)
+    if [ -z "$lib_path" ]
+    then
+        # potential for non-debian-based systems
+        lib_path=$(find /usr/lib /usr/local/lib -name 'opensc-pkcs11.so' 2>/dev/null | head -1)
+    fi
+    echo "$lib_path"
+} # find_opensc_pkcs11
+
+
+# Register opensc-pkcs11.so as a PKCS11 module in a single NSS database dir.
+register_pkcs11_module ()
+{
+    local db_dir="$1"
+    local lib_path="$2"
+    print_info "Registering PKCS11 module in ${db_dir}..."
+    sudo -H -u "$SUDO_USER" modutil -dbdir "sql:${db_dir}" \
+        -add "CAC Module" -libfile "$lib_path" -force
+} # register_pkcs11_module
 
 
 main

--- a/cac_setup.sh
+++ b/cac_setup.sh
@@ -38,8 +38,8 @@ main ()
 
     # Install middleware and necessary utilities
     print_info "Installing middleware and essential utilities..."
-    apt update
-    DEBIAN_FRONTEND=noninteractive apt install -y libpcsclite1 pcscd libccid libpcsc-perl pcsc-tools libnss3-tools unzip wget opensc
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y libpcsclite1 pcscd libccid libpcsc-perl pcsc-tools libnss3-tools unzip wget opensc
     print_info "Done"
 
     # Pull all necessary files
@@ -82,7 +82,7 @@ main ()
             -add "CAC Module" -libfile /usr/lib/x86_64-linux-gnu/opensc-pkcs11.so -force
     else
         print_info "Registering CAC module with PKSC11..."
-        pkcs11-register
+        sudo -H -u "$SUDO_USER" pkcs11-register --skip-firefox=off
         print_info "Done"
 
         # NOTE: Keeping this temporarily to test `pkcs11-register`.

--- a/test/README.md
+++ b/test/README.md
@@ -15,6 +15,7 @@ distribution versions.
 - vagrant
 - virtualbox (other backends, e.g. QEMU, are possible but would require changes
   to the `Vagrantfile`)
+- `genisoimage` or whichever package provides `mkisofs`
 - web connectivity
 
 ## Usage

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,34 @@
+# Integration testing
+
+Vagrant-based testing for the `cac_setup.sh` script.
+
+## Overview
+
+The goal is to alleviate testing across various distributions. This solution is
+not ideal as it's impractical to integrate into a CI/CD pipeline without custom
+runners; however, it should suffice to conveniently provide a fair measure of
+assurance that the script functions as intended across a set of given
+distribution versions.
+
+## Prerequisites
+
+- vagrant
+- virtualbox (other backends, e.g. QEMU, are possible but would require changes
+  to the `Vagrantfile`)
+- web connectivity
+
+## Usage
+
+```bash
+# run all VMs
+vagrant up
+
+# run a specific VM
+vagrant up ubuntu2404
+
+# rerun tests only
+vagrant provision ubuntu2404 --provision-with test
+
+# wipe clean
+vagrant destroy
+```

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -1,0 +1,62 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  # expose repo root to the VMs
+  config.vm.synced_folder "..", "/vagrant_root"
+
+  DISTROS = {
+    "ubuntu2404" => {
+      box: "cloud-image/ubuntu-24.04",
+      box_version: "20260323.0.0",
+      pre_setup: <<~SHELL
+        snap install firefox
+      SHELL
+    },
+
+    "debian13" => {
+      box: "cloud-image/debian-13",
+      box_version: "20260413.2447.0",
+      pre_setup: <<~SHELL
+        apt-get install -qy firefox-esr
+      SHELL
+    }
+  }
+
+  DISTROS.each do |name, cfg|
+    config.vm.define name do |node|
+      node.vm.box = cfg[:box]
+      node.vm.box_version = cfg[:box_version]
+
+      node.vm.cloud_init do |cloud_init|
+        cloud_init.content_type = "text/cloud-config"
+        cloud_init.inline = <<-EOF
+          timezone: America/New_York
+          package_update: true
+          packages:
+            - bats
+        EOF
+      end
+
+      node.vm.provider :virtualbox do |vb|
+        vb.memory = "2048"
+        vb.cpus   = 2
+        vb.name   = "linux_cac_#{name}"
+      end
+
+      # 1: install browsers
+      node.vm.provision "pre_setup", type: "shell", inline: cfg[:pre_setup]
+
+      # 2: run cac_setup.sh
+      node.vm.provision "cac_setup", type: "shell", inline: <<~SHELL
+        SUDO_USER=vagrant bash /vagrant_root/cac_setup.sh
+        echo $? > /tmp/cac_setup_exit_code
+      SHELL
+
+      # 3: run the tests
+      node.vm.provision "test", type: "shell", inline: <<~SHELL
+        bats /vagrant_root/test/test.bats
+      SHELL
+    end
+  end
+end

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -11,6 +11,8 @@ Vagrant.configure("2") do |config|
       box_version: "20260323.0.0",
       pre_setup: <<~SHELL
         snap install firefox
+        wget -qO /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+        apt-get install -y /tmp/chrome.deb
       SHELL
     },
 
@@ -19,6 +21,8 @@ Vagrant.configure("2") do |config|
       box_version: "20260413.2447.0",
       pre_setup: <<~SHELL
         apt-get install -qy firefox-esr
+        wget -qO /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+        apt-get install -y /tmp/chrome.deb
       SHELL
     }
   }

--- a/test/test.bats
+++ b/test/test.bats
@@ -13,6 +13,10 @@ ff_profile() {
     | head -1 | xargs -I{} dirname {}
 }
 
+chrome_profile() {
+  echo "/home/vagrant/.local/share/pki/nssdb"
+}
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -42,9 +46,7 @@ ff_profile() {
   run modutil -dbdir sql:${profile} -list 2>&1
   [ "$status" -eq 0 ]
 
-  # Snap path:     "CAC Module"
-  # Non-snap path: "OpenSC smartcard framework" (name set by pkcs11-register)
-  echo "$output" | grep -qi "CAC Module\|OpenSC"
+  echo "$output" | grep -qi "CAC Module"
 }
 
 @test "DoD certificates imported into Firefox profile" {
@@ -54,5 +56,17 @@ ff_profile() {
 
   cert_count=$(certutil -d "sql:${profile}" -L 2>/dev/null | grep -c '\.cer' || echo 0)
   # arbitrary number
+  [ "$cert_count" -gt 10 ]
+}
+
+@test "PKCS11 module registered in Chrome" {
+  run modutil -dbdir "sql:$(chrome_profile)" -list 2>&1
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qi "CAC Module"
+}
+
+@test "DoD certificates imported into Chrome profile" {
+  local cert_count
+  cert_count=$(certutil -d "sql:$(chrome_profile)" -L 2>/dev/null | grep -c '\.cer' || echo 0)
   [ "$cert_count" -gt 10 ]
 }

--- a/test/test.bats
+++ b/test/test.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+# test.bats
+# Description: tests for cac_setup.sh
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+ff_profile() {
+  find /home/vagrant -name "cert9.db" 2>/dev/null \
+    | grep "firefox" | grep -v "Trash" \
+    | head -1 | xargs -I{} dirname {}
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@test "cac_setup.sh exited successfully" {
+  run cat /tmp/cac_setup_exit_code
+  [ "$status" -eq 0 ]
+  [ "$output" = "0" ]
+}
+
+@test "pcscd.socket enabled" {
+  run systemctl is-enabled pcscd.socket
+  [ "$status" -eq 0 ]
+}
+
+@test "pcscd.socket starts cleanly" {
+  systemctl start pcscd.socket
+  run systemctl is-active pcscd.socket
+  [ "$status" -eq 0 ]
+}
+
+@test "PKCS11 module registered in Firefox" {
+  local profile
+  profile=$(ff_profile)
+  [ -n "$profile" ]
+
+  run modutil -dbdir sql:${profile} -list 2>&1
+  [ "$status" -eq 0 ]
+
+  # Snap path:     "CAC Module"
+  # Non-snap path: "OpenSC smartcard framework" (name set by pkcs11-register)
+  echo "$output" | grep -qi "CAC Module\|OpenSC"
+}
+
+@test "DoD certificates imported into Firefox profile" {
+  local profile cert_count
+  profile=$(ff_profile)
+  [ -n "$profile" ]
+
+  cert_count=$(certutil -d "sql:${profile}" -L 2>/dev/null | grep -c '\.cer' || echo 0)
+  # arbitrary number
+  [ "$cert_count" -gt 10 ]
+}


### PR DESCRIPTION
CI testing would be ideal but I found most approaches to be cumbersome given the direct involvement of `systemd`. The Vagrant approach in this PR accomplishes more-or-less automated testing by running the script on Ubuntu 24.04/Debian 13 instances and calling BATS tests to determine that

- the script ran successfully
- pcscd socket is active
- pkcs11 module registered in ff/chrome profiles
- dod certs got imported

There is probably a better way to isolate re-running the script on a provisioned system's clean state in the `Vagrantfile` but I don't yet know enough ruby/vagrant to pull that off so a typical workflow is:

```bash
vagrant up
# box A spins up
# script runs
# test runs
# box B spins up
# script runs
# test runs
vagrant destroy
```

In case of a failure in a test, vagrant process quits but it's possible to

```bash
vagrant ssh <box-name>
```

because provisioned boxes continue running and determine exactly what happened but once fixed the entire procedure has to repeat to ensure a clean state.

---

On a separate note, during testing I found that `pkcs11-register` is really only useful for apt-installed Firefox (and even then there are annoying interface [differences](https://github.com/OpenSC/OpenSC/commit/0ccc20f481b179b59d798dc8c41ba154e55811e8) between versions in upstream Ubuntu and Debian repos) and decided to switch entirely to `modutil` for module registration (which also proved cleaner as it was already being used for snapped FF).