### PR TITLE
Adding Ubuntu 26.0.4 Support

### DIFF
--- a/cac_setup.sh
+++ b/cac_setup.sh
@@ -147,26 +147,17 @@ root_check ()
 run_firefox ()
 {
     print_info "Starting Firefox silently to complete post-install actions..."
-    sudo -H -u "$SUDO_USER" firefox --headless --first-startup >/dev/null 2>&1 &
-    sleep 3
-    pkill -9 firefox
-    sleep 1
+    sudo -H -u "$SUDO_USER" firefox --headless --first-startup --screenshot /dev/null about:blank &>/dev/null || true
+    print_info "Done running Firefox."
 } # run_firefox
 
 
 # Run Chrome to ensure .pki directory has been created
 run_chrome ()
 {
-    # NOTE: this is the original
-    # sudo -H -u "$SUDO_USER" bash -c 'google-chrome --headless --disable-gpu >/dev/null 2>&1 &'
-
-    # TODO: finish troubleshooting this
     print_info "Running Chrome to ensure it has completed post-install actions..."
-    sudo -H -u "$SUDO_USER" google-chrome --headless --disable-gpu >/dev/null 2>&1 &
-    sleep 3
-    pkill -9 google-chrome
-    sleep 1
-    print_info "Done."
+    sudo -H -u "$SUDO_USER" google-chrome --headless --disable-gpu --screenshot=/dev/null about:blank &>/dev/null || true
+    print_info "Done running Chrome."
 } # run_chrome
 
 

--- a/cac_setup.sh
+++ b/cac_setup.sh
@@ -16,6 +16,9 @@ main ()
     snap_ff=false                       # Snapped Firefox
     ff_profile_dir=""                   # Firefox profile directory
 
+    export DEBIAN_FRONTEND=noninteractive
+    export NEEDRESTART_MODE=a
+
     ORIG_HOME="$(getent passwd "$SUDO_USER" | cut -d: -f6)"
     CERT_EXTENSION="cer"
     # PKCS_FILENAME="pkcs11.txt"
@@ -39,7 +42,7 @@ main ()
     # Install middleware and necessary utilities
     print_info "Installing middleware and essential utilities..."
     apt update
-    DEBIAN_FRONTEND=noninteractive apt install -y libpcsclite1 pcscd libccid libpcsc-perl pcsc-tools libnss3-tools unzip wget opensc
+    apt install -y libpcsclite1 pcscd libccid libpcsc-perl pcsc-tools libnss3-tools unzip wget opensc
     print_info "Done"
 
     # Pull all necessary files


### PR DESCRIPTION
This was ran on initial boot into a new install of Ubuntu.

The OS was installed using Ubuntu Server 26.0.4 with kubuntu-desktop installed on top of it.

Upon first logging in to the kde desktop and executing, it succeeds and CAC works for both chrome and snap version of firefox.